### PR TITLE
Logical changes for determining whether or not the link is internal or external

### DIFF
--- a/javascript/event-tracking-universal.js
+++ b/javascript/event-tracking-universal.js
@@ -3,6 +3,7 @@
 	$(document).ready(function() {
 	
 		var filetypes = /\.(zip|exe|dmg|pdf|doc.*|xls.*|ppt.*|mp3|txt|rar|wma|mov|avi|wmv|flv|wav)$/i;
+		var TLDPrimary = /(com|org|net|int|edu|gov|mil|vic|nsw|qld)$/i;
 		var baseHref = '';
 		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
 		var hrefRedirect = '';
@@ -11,7 +12,36 @@
 			var el = $(this);
 			var track = true;
 			var href = (typeof(el.attr('href')) != 'undefined' ) ? el.attr('href') : '';
-			var isThisDomain = href.match(document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0]);
+			var reverseDomain = document.domain.split('.').reverse();
+			var domainBase = 0;
+
+			for(i = 0; i < reverseDomain.length; i++) {
+				if(reverseDomain[i].length >= 3 && !reverseDomain[i].match(TLDPrimary)) {
+					domainBase = i;
+					break;
+				}
+			}
+
+			if(domainBase == 0 && reverseDomain[0] != 'localhost')
+				domainBase = 1;
+
+			var siteBase = '';
+
+			for(i = 0; i <= domainBase; i++) {
+				if(siteBase == '')
+					siteBase = reverseDomain[i] + siteBase;
+				else
+					siteBase = reverseDomain[i] + '.' + siteBase;
+			}
+			siteBase += '/';
+			
+			var isThisDomain = false;
+
+			if(href.match(/(http)$/i))
+				isThisDomain = href.match(siteBase);
+			else if (href.indexOf('/') === 0)
+				isThisDomain = true;
+
 			if (!href.match(/^javascript:/i)) {
 				var elEv = []; elEv.value=0, elEv.non_i=false;
 				if (href.match(/^mailto\:/i)) {
@@ -19,13 +49,6 @@
 					elEv.action = 'click';
 					elEv.label = href.replace(/^mailto\:/i, '');
 					elEv.loc = href;
-				}
-				else if (href.match(filetypes)) {
-					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
-					elEv.category = 'download';
-					elEv.action = 'click-' + extension[0];
-					elEv.label = href.replace(/ /g,'-');
-					elEv.loc = baseHref + href;
 				}
 				else if (el.hasClass('download')) { 
 					// extra for dms module. 
@@ -42,6 +65,13 @@
 					elEv.label = href.replace(/^https?\:\/\//i, '');
 					elEv.non_i = true;
 					elEv.loc = href;
+				}
+				else if (href.match(filetypes)) {
+					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
+					elEv.category = 'download';
+					elEv.action = 'click-' + extension[0];
+					elEv.label = href.replace(/ /g,'-');
+					elEv.loc = baseHref + href;
 				}
 				else if (href.match(/^tel\:/i)) {
 					elEv.category = 'telephone';

--- a/javascript/event-tracking.js
+++ b/javascript/event-tracking.js
@@ -3,14 +3,45 @@
 	$(document).ready(function() {
 	
 		var filetypes = /\.(zip|exe|dmg|pdf|doc.*|xls.*|ppt.*|mp3|txt|rar|wma|mov|avi|wmv|flv|wav)$/i;
+		var TLDPrimary = /(com|org|net|int|edu|gov|mil|vic|nsw|qld)$/i;
 		var baseHref = '';
 		if ($('base').attr('href') != undefined) baseHref = $('base').attr('href');
-		 
-		$('a').on('click', function(event) {
+		var hrefRedirect = '';
+	 
+		$('body').on('click', 'a', function(event) {
 			var el = $(this);
 			var track = true;
-			var href = (typeof(el.attr('href')) != 'undefined' ) ? el.attr('href') :"";
-			var isThisDomain = href.match(document.domain.split('.').reverse()[1] + '.' + document.domain.split('.').reverse()[0]);
+			var href = (typeof(el.attr('href')) != 'undefined' ) ? el.attr('href') : '';
+			var reverseDomain = document.domain.split('.').reverse();
+			var domainBase = 0;
+
+			for(i = 0; i < reverseDomain.length; i++) {
+				if(reverseDomain[i].length >= 3 && !reverseDomain[i].match(TLDPrimary)) {
+					domainBase = i;
+					break;
+				}
+			}
+
+			if(domainBase == 0 && reverseDomain[0] != 'localhost')
+				domainBase = 1;
+
+			var siteBase = '';
+
+			for(i = 0; i <= domainBase; i++) {
+				if(siteBase == '')
+					siteBase = reverseDomain[i] + siteBase;
+				else
+					siteBase = reverseDomain[i] + '.' + siteBase;
+			}
+			siteBase += '/';
+			
+			var isThisDomain = false;
+
+			if(href.match(/(http)$/i))
+				isThisDomain = href.match(siteBase);
+			else if (href.indexOf('/') === 0)
+				isThisDomain = true;
+			
 			if (!href.match(/^javascript:/i)) {
 				var elEv = []; elEv.value=0, elEv.non_i=false;
 				if (href.match(/^mailto\:/i)) {
@@ -18,13 +49,6 @@
 					elEv.action = "click";
 					elEv.label = href.replace(/^mailto\:/i, '');
 					elEv.loc = href;
-				}
-				else if (href.match(filetypes)) {
-					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
-					elEv.category = "download";
-					elEv.action = "click-" + extension[0];
-					elEv.label = href.replace(/ /g,"-");
-					elEv.loc = baseHref + href;
 				}
 				else if (el.hasClass('download')) { 
 					// extra for dms module. 
@@ -41,6 +65,13 @@
 					elEv.label = href.replace(/^https?\:\/\//i, '');
 					elEv.non_i = true;
 					elEv.loc = href;
+				}
+				else if (href.match(filetypes)) {
+					var extension = (/[.]/.exec(href)) ? /[^.]+$/.exec(href) : undefined;
+					elEv.category = "download";
+					elEv.action = "click-" + extension[0];
+					elEv.label = href.replace(/ /g,"-");
+					elEv.loc = baseHref + href;
 				}
 				else if (href.match(/^tel\:/i)) {
 					elEv.category = "telephone";


### PR DESCRIPTION
Previously there were a few bugs with this relating to assumptions around the TLD.
You could do http://domain.com fine, but it would evaluate com.au instead of domain.com if you had http://domain.com.au for example.
This logical fix expands on possiblities however it still makes assumptions, but should be more forgiving than just a single TLD.

The order of determining if tracking a file has also been changed since there were assumptions being made that a file would always be hosted at the current domain.
This had consequences of chaining the external domain on to the internal domain like so : http://internal.com/something/http://external.com/file.txt
