### PR TITLE
feat: add SilverStripe 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 
 	"require": {
-		"silverstripe/framework": "^5"
+		"silverstripe/framework": "^6"
 	},
     "autoload": {
         "psr-4": {

--- a/src/Extensions/ConfigExtension.php
+++ b/src/Extensions/ConfigExtension.php
@@ -2,12 +2,12 @@
 
 namespace Innoweb\GoogleAnalytics\Extensions;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
-use SilverStripe\ORM\DataExtension;
 
-class ConfigExtension extends DataExtension
+class ConfigExtension extends Extension
 {
 
     private static $db = [


### PR DESCRIPTION
## Summary

Adds SilverStripe 6 support:

1. Bumps `silverstripe/framework` constraint from `^5` to `^6`
2. Replaces `SilverStripe\ORM\DataExtension` with `SilverStripe\Core\Extension` in `ConfigExtension` — `DataExtension` was removed in SS6; all extensions now extend `Extension` directly

## Testing

Tested as a VCS fork dependency in a SS6 recipe CI environment — both PHP 8.3 and 8.4 pass.

## Related

`innoweb/silverstripe-social-metadata` and `innoweb/silverstripe-social-share` have already been upgraded to SS6 (`^9` and `^5` respectively), so this completes the innoweb suite for SS6.